### PR TITLE
docs(ci_cd): fix indent error for perform release CI

### DIFF
--- a/src/ci_cd/README.md
+++ b/src/ci_cd/README.md
@@ -88,30 +88,35 @@ you can directly use `cog`.
 on:
   workflow_dispatch:
     branches: main
-    
+
 jobs:
   release:
     name: Perform release
-        - uses: actions/checkout@v3
-            with:
-              fetch-depth: 0
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-        - name: Cocogitto release
-          id: release
-          uses: oknozor/cocogitto-action@v3
-          with:
-            release: true
-              git-user: 'Cog Bot'
-              git-user-email: 'mycoolproject@org.org'
+      - name: Cocogitto release
+        id: release
+        uses: oknozor/cocogitto-action@v3
+        with:
+          release: true
+          git-user: 'Cog Bot'
+          git-user-email: 'mycoolproject@org.org'
 
-        - name: Generate Changelog
-          run: cog changelog --at ${{ steps.release.outputs.version }} -t full_hash > GITHUB_CHANGELOG.md
+      - name: Generate Changelog
+        run: cog changelog --at ${{ steps.release.outputs.version }} -t full_hash > GITHUB_CHANGELOG.md
 
-        - name: Upload github release
-          uses: softprops/action-gh-release@v1
-          with:
-            body_path: GITHUB_CHANGELOG.md
-            tag_name: ${{ steps.release.outputs.version }}
+      - name: Upload github release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: GITHUB_CHANGELOG.md
+          tag_name: ${{ steps.release.outputs.version }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 ```
 
 Also see:


### PR DESCRIPTION
I have created a repository [cog-ci-test](https://github.com/jiangyinzuo/cog-ci-test) to validate the modified yml configuration.

The former yml configuration has some indent errors and misses some necessary configurations (`runs-on`, `permissions`, ...).